### PR TITLE
Fix: CI/CD pipeline and Dockerfile

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -12,12 +12,12 @@ jobs:
         run: |
           echo "Running on branch ${{ github.ref }}"
           if [ "${{ github.ref }}" = "refs/heads/production" ]; then
-            echo "::set-output name=env_name::production"
+            echo "env_name=Production" >> $GITHUB_OUTPUT
           elif [ "${{ github.ref }}" = "refs/heads/development" ]; then
-            echo "::set-output name=env_name::development"
+            echo "env_name=Development" >> $GITHUB_OUTPUT
           else
-             echo "::set-output name=env_name::development"
-          fi 
+            echo "env_name=Development" >> $GITHUB_OUTPUT
+          fi
     outputs:
       env_name: ${{ steps.branch_check.outputs.env_name }}
 
@@ -28,7 +28,7 @@ jobs:
     environment: ${{ needs.environment_check.outputs.env_name }}
     steps:
       - name: Checkout master
-        uses: actions/checkout@main
+        uses: actions/checkout@v4
 
       - name: Install doctl
         uses: digitalocean/action-doctl@v2
@@ -40,7 +40,7 @@ jobs:
 
       - name: Update Backend image in Digital Ocean Artifact Registry
         id: docker-push-tagged
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           push: true
           file: ./Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 # Pull official base image
-FROM python:3.9-slim-buster as builder
+FROM python:3.9-slim-bookworm AS builder
 # Set up work directory
 WORKDIR /usr/src/app
 RUN mkdir /usr/src/tmp
 # Install required unix libraries
 # Set environment variables
-ENV PYTHONDONTWRITEBYTECODE 1
-ENV PYTHONUNBUFFERED 1
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
 # Install dependencies
 RUN python -m pip install -U --force-reinstall pip
 COPY ./requirements.txt .
@@ -18,7 +18,7 @@ RUN sed -i 's/\r$//g' /usr/src/app/entrypoint.sh
 RUN chmod +x /usr/src/app/entrypoint.sh
 # Copy project
 
-FROM python:3.9-slim-buster as main
+FROM python:3.9-slim-bookworm AS main
 # create the app user
 # create the appropriate directories
 ENV HOME=/home/app
@@ -28,7 +28,7 @@ WORKDIR $APP_HOME
 
 # install dependencies
 RUN apt-get update &&\
-	yes | apt-get install binutils libproj-dev gdal-bin python-gdal python3-gdal
+	yes | apt-get install binutils libproj-dev gdal-bin python3-gdal
 
 # Parse env variables to .env file
 RUN --mount=type=secret,id=ENV_SECRETS cat /run/secrets/ENV_SECRETS | base64 -d >> $APP_HOME/.env


### PR DESCRIPTION
## Summary
- **Dockerfile**: Upgrade base image from EOL `python:3.9-slim-buster` to `python:3.9-slim-bookworm` (Debian Buster repos return 404, breaking `apt-get update`)
- **Dockerfile**: Remove `python-gdal` (Python 2 package, doesn't exist in Bookworm), fix `ENV` format and `AS` casing warnings
- **deploy.yaml**: Fix environment name casing (`development` → `Development`, `production` → `Production`) so the build job can find GitHub environment secrets
- **deploy.yaml**: Replace deprecated `::set-output` with `$GITHUB_OUTPUT`, pin `actions/checkout@v4` and `docker/build-push-action@v5`

## Test plan
- [ ] Merge to `development` and verify the GitHub Actions workflow succeeds
- [ ] Confirm the Docker image appears in the DigitalOcean container registry
- [ ] Force redeploy in App Platform and verify deploy logs show pending migration applied
- [ ] If successful, merge `development` → `production`

🤖 Generated with [Claude Code](https://claude.com/claude-code)