### PR TITLE
Fix: Pin numpy for pandas compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ coreapi==2.3.3
 gunicorn==20.1.0
 django-storages==1.12.3
 boto3==1.24.2
+numpy==1.23.5
 pandas==1.4.2
 geoip2==4.5.0
 djangorestframework-simplejwt==5.2.0


### PR DESCRIPTION
## Summary
- Pin `numpy==1.23.5` to fix binary incompatibility with `pandas==1.4.2` on Debian Bookworm
- Without this, the migration loader crashes on `0009_readd_locations.py` (which imports pandas), preventing ALL migrations from running — including `0013` which adds the `is_listing` column to Category

## Test plan
- [ ] Merge to `development`, verify workflow succeeds
- [ ] Merge to `production`, verify `python manage.py migrate` runs in deploy logs
- [ ] Confirm categories load without 500 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)