### PR TITLE
Release Mar 5: Pin numpy, fix CI/CD pipeline

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ coreapi==2.3.3
 gunicorn==20.1.0
 django-storages==1.12.3
 boto3==1.24.2
+numpy==1.23.5
 pandas==1.4.2
 geoip2==4.5.0
 djangorestframework-simplejwt==5.2.0


### PR DESCRIPTION
## Summary
- Pin `numpy==1.23.5` to fix pandas binary incompatibility on Bookworm (fixes migration loader crash)
- Includes prior CI/CD and Dockerfile fixes from earlier today

## Test plan
- [ ] Verify deploy logs show migrations running successfully
- [ ] Confirm categories load without 500 errors on production

🤖 Generated with [Claude Code](https://claude.com/claude-code)